### PR TITLE
Clean up unrooted boot patching cp errors in log

### DIFF
--- a/app/src/main/java/com/topjohnwu/magisk/core/tasks/MagiskInstaller.kt
+++ b/app/src/main/java/com/topjohnwu/magisk/core/tasks/MagiskInstaller.kt
@@ -456,10 +456,7 @@ abstract class MagiskInstallImpl protected constructor(
             return false
         }
 
-        // Fix up binaries
         srcBoot.delete()
-        "cp_readlink $installDir".sh()
-
         return true
     }
 


### PR DESCRIPTION
cp: can't preserve ownership of 'busybox': Operation not permitted
cp: can't preserve ownership of 'magisk32': Operation not permitted
cp: can't preserve ownership of 'magisk64': Operation not permitted
cp: can't preserve ownership of 'magiskboot': Operation not permitted
cp: can't preserve ownership of 'magiskinit': Operation not permitted
cp: can't preserve ownership of 'magiskpolicy': Operation not permitted

remove call since cp_readlink shouldn't be necessary with installDir getting cleaned up regularly

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have read the [Code of Conduct](https://github.com/danopstech/.github/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have updated the documentation accordingly.
- [ ] All commits are GPG signed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined the installation process by removing redundant binary fix-up logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->